### PR TITLE
Changed configuration key to avoid collisions with other modules

### DIFF
--- a/src/Plugin/Condition/UuidCondition.php
+++ b/src/Plugin/Condition/UuidCondition.php
@@ -31,17 +31,17 @@ class UuidCondition extends ConditionPluginBase {
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return array('uuid' => '') + parent::defaultConfiguration();
+    return array('uuids' => '') + parent::defaultConfiguration();
   }
 
   /**
    * {@inheritdoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-    $form['uuid'] = array(
+    $form['uuids'] = array(
       '#title' => $this->t('Entity UUIDs, one per line'),
       '#type' => 'textarea',
-      '#default_value' => $this->configuration['uuid'],
+      '#default_value' => $this->configuration['uuids'],
     );
     return parent::buildConfigurationForm($form, $form_state);
   }
@@ -50,7 +50,7 @@ class UuidCondition extends ConditionPluginBase {
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
-    $this->configuration['uuid'] = $form_state->getValue('uuid');
+    $this->configuration['uuids'] = $form_state->getValue('uuids');
     parent::submitConfigurationForm($form, $form_state);
   }
 
@@ -58,15 +58,15 @@ class UuidCondition extends ConditionPluginBase {
    * {@inheritdoc}
    */
   public function summary() {
-    $uuid = $this->configuration['uuid'];
-    return $this->t('The entity id configuration is @uuid', array('@uuid' => $uuid));
+    $uuids = $this->configuration['uuids'];
+    return $this->t('The entity id configuration is @uuids', array('@uuids' => $uuids));
   }
 
   /**
    * {@inheritdoc}
    */
   public function evaluate() {
-    if (empty($this->configuration['uuid'])) {
+    if (empty($this->configuration['uuids'])) {
       // Pass through if no configuration found.
       return TRUE;
     }
@@ -86,7 +86,7 @@ class UuidCondition extends ConditionPluginBase {
     }
 
     // Return TRUE if the uuid matches any uuid in the block configuration.
-    if (strpos($this->configuration['uuid'], $uuid) !== FALSE) {
+    if (strpos($this->configuration['uuids'], $uuid) !== FALSE) {
       return TRUE;
     }
   }

--- a/tests/src/Unit/UuidConditionTest.php
+++ b/tests/src/Unit/UuidConditionTest.php
@@ -74,7 +74,7 @@ class UuidConditionTest extends UnitTestCase {
   public function evaluateAlwaysTrueWithNoContext() {
     // Set some config to ensure the context is checked.
     $mock_config = $this->getConfigTemplateStub();
-    $mock_config['uuid'] = self::MOCK_UUID;
+    $mock_config['uuids'] = self::MOCK_UUID;
 
     $this->plugin->setConfiguration($mock_config);
     $this->assertEquals(FALSE, $this->plugin->evaluate(), 'Plugin evaluated with no context should always evaluate to FALSE');
@@ -112,7 +112,7 @@ class UuidConditionTest extends UnitTestCase {
 
     $mock_config = $this->getConfigTemplateStub();
     foreach ($mock_uuid_configs as $message => $config) {
-      $mock_config['uuid'] = $config;
+      $mock_config['uuids'] = $config;
       $this->plugin->setConfiguration($mock_config);
       // Test without a context with no uuid config.
       $this->assertEquals(TRUE, $this->plugin->evaluate(), "Plugin should evaluate to TRUE when valid uuid is $message.");
@@ -142,7 +142,7 @@ class UuidConditionTest extends UnitTestCase {
 
     // Mock config.
     $mock_config = $this->getConfigTemplateStub();
-    $mock_config['uuid'] = $mock_config_uuid;
+    $mock_config['uuids'] = $mock_config_uuid;
     $this->plugin->setConfiguration($mock_config);
 
     $this->assertEquals(FALSE, $this->plugin->evaluate(), "Plugin should evaluate to FALSE when the context uuid does not match config.");
@@ -158,7 +158,7 @@ class UuidConditionTest extends UnitTestCase {
     return array(
       'id' => 'uuid',
       'negate' => FALSE,
-      'uuid' => '',
+      'uuids' => '',
       'context_mapping' => array(
         'node' => '@node.node_route_context:node',
       ),


### PR DESCRIPTION
Some modules add their own UUID when creating plugin instances, this overrides the configuration value set by this condition and it silently fails without saving.